### PR TITLE
Implemented winter supplement calculations in the rules engine

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 HOST = 'test.mosquitto.org'
 PORT = 1883
-TOPIC_ID = 'f114dcc8-bf19-4e73-a4ac-8aae8f77518c' # TODO pass this via command line arg?
+KEEP_ALIVE = 60
+TOPIC_ID = '44574422-0088-4f4e-83e4-053dffd7c65a'
 INPUT_TOPIC = 'BRE/calculateWinterSupplementInput'
 OUTPUT_TOPIC = 'BRE/calculateWinterSupplementOutput'

--- a/config.py
+++ b/config.py
@@ -1,5 +1,5 @@
 HOST = 'test.mosquitto.org'
 PORT = 1883
-TOPIC_ID = '437c83fa-60bb-4c5f-b80c-bc3ea9476b19'
+TOPIC_ID = 'f114dcc8-bf19-4e73-a4ac-8aae8f77518c' # TODO pass this via command line arg?
 INPUT_TOPIC = 'BRE/calculateWinterSupplementInput'
 OUTPUT_TOPIC = 'BRE/calculateWinterSupplementOutput'

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,17 @@
+INELIGIBLE_AMOUNT = 0.0 
+
+BASE_AMOUNTS = {
+    'winter_supplement': {
+        'single': 60,
+        'couple': 120
+    }
+}
+
+PER_CHILD_AMOUNTS = {
+    'winter_supplement': 20
+}
+
+FAMILY_COMPOSITIONS = {
+    'single',
+    'couple'
+}

--- a/main.py
+++ b/main.py
@@ -2,8 +2,8 @@ import json
 
 import paho.mqtt.client as mqtt
 
-from config import *
-from rules_engine import calculate_winter_supplement
+from config import HOST, INPUT_TOPIC, KEEP_ALIVE, OUTPUT_TOPIC, PORT, TOPIC_ID
+from rules_engine import calculate_supplement
 from validation import validate_winter_supplement_input_data
 
 
@@ -25,7 +25,8 @@ def on_message(client, userdata, msg):
         print(f'Unexpected error: {e}')
         return
 
-    calculated_amounts = calculate_winter_supplement(
+    calculated_amounts = calculate_supplement(
+        'winter_supplement',
         input_data['numberOfChildren'], 
         input_data['familyComposition'],
         input_data['familyUnitInPayForDecember']
@@ -39,13 +40,14 @@ def on_message(client, userdata, msg):
         "supplementAmount": calculated_amounts['supplementAmount'] 
     }
     encoded_output_data = json.dumps(output_data, indent=2).encode('utf-8')
-
+    # TODO web app not publishing? delete this later, currently publishing from CLI
+    print(encoded_output_data) 
     client.publish(f'{OUTPUT_TOPIC}/{TOPIC_ID}', encoded_output_data)
 
 mqttc = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
 mqttc.on_connect = on_connect
 mqttc.on_message = on_message
 
-mqttc.connect(HOST, PORT, 60)
+mqttc.connect(HOST, PORT, KEEP_ALIVE)
 
 mqttc.loop_forever()

--- a/main.py
+++ b/main.py
@@ -1,12 +1,34 @@
+import json
+
 import paho.mqtt.client as mqtt
+
 from config import *
+from rules_engine import calculate_winter_supplement
+
 
 def on_connect(client, userdata, flags, reason_code, properties):
     print(f'Connected with result code {reason_code}')
     client.subscribe(f'{INPUT_TOPIC}/{TOPIC_ID}')
 
 def on_message(client, userdata, msg):
-    print(msg.topic+" "+str(msg.payload))
+    print(f'{msg.topic}: {msg.payload}')
+
+    input_data = json.loads(msg.payload)
+    # TODO validate input_data
+    calculated_amounts = calculate_winter_supplement(input_data['numberOfChildren'], 
+                                                     input_data['familyComposition'], 
+                                                     input_data['familyUnitInPayForDecember'])
+
+    output_data = {
+        "id": input_data['id'], 
+        "isEligible": input_data['isEligible'], 
+        "baseAmount": calculated_amounts['baseAmount'],
+        "childrenAmount": calculated_amounts['childrenAmount'], 
+        "supplementAmount": calculated_amounts['supplementAmount'] 
+    }
+    encoded_output_data = json.dumps(output_data, indent=2).encode('utf-8')
+
+    client.publish(f'{OUTPUT_TOPIC}/{TOPIC_ID}', encoded_output_data)
 
 mqttc = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
 mqttc.on_connect = on_connect

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import paho.mqtt.client as mqtt
 
 from config import *
 from rules_engine import calculate_winter_supplement
-from validation import validate_input_data
+from validation import validate_winter_supplement_input_data
 
 
 def on_connect(client, userdata, flags, reason_code, properties):
@@ -16,18 +16,20 @@ def on_message(client, userdata, msg):
 
     input_data = json.loads(msg.payload)
     try:
-        validate_input_data(input_data)
+        validate_winter_supplement_input_data(input_data)
     except ValueError as e:
-        print(f'Input validation error {e}')
+        print(f'Input validation error: {e}')
         # TODO publish error message with 0 values, it does nothing but would be good practice I think
         return
     except Exception as e:
-        print(f'Unexpected error {e}')
+        print(f'Unexpected error: {e}')
         return
 
-    calculated_amounts = calculate_winter_supplement(input_data['numberOfChildren'], 
-                                                     input_data['familyComposition'], 
-                                                     input_data['familyUnitInPayForDecember'])
+    calculated_amounts = calculate_winter_supplement(
+        input_data['numberOfChildren'], 
+        input_data['familyComposition'],
+        input_data['familyUnitInPayForDecember']
+        )
 
     output_data = {
         "id": input_data['id'], 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import paho.mqtt.client as mqtt
 
 from config import *
 from rules_engine import calculate_winter_supplement
+from validation import validate_input_data
 
 
 def on_connect(client, userdata, flags, reason_code, properties):
@@ -14,14 +15,23 @@ def on_message(client, userdata, msg):
     print(f'{msg.topic}: {msg.payload}')
 
     input_data = json.loads(msg.payload)
-    # TODO validate input_data
+    try:
+        validate_input_data(input_data)
+    except ValueError as e:
+        print(f'Input validation error {e}')
+        # TODO publish error message with 0 values, it does nothing but would be good practice I think
+        return
+    except Exception as e:
+        print(f'Unexpected error {e}')
+        return
+
     calculated_amounts = calculate_winter_supplement(input_data['numberOfChildren'], 
                                                      input_data['familyComposition'], 
                                                      input_data['familyUnitInPayForDecember'])
 
     output_data = {
         "id": input_data['id'], 
-        "isEligible": input_data['isEligible'], 
+        "isEligible": input_data['familyUnitInPayForDecember'], 
         "baseAmount": calculated_amounts['baseAmount'],
         "childrenAmount": calculated_amounts['childrenAmount'], 
         "supplementAmount": calculated_amounts['supplementAmount'] 

--- a/rules_engine.py
+++ b/rules_engine.py
@@ -1,0 +1,34 @@
+def calculate_base_amount(family_composition):
+    match family_composition:
+        case 'single':
+            base_amount = 60
+        case 'couple':
+            base_amount = 120
+        case _:
+            #TODO i dont like this, revisit later
+            base_amount = -1
+
+    return base_amount
+
+def calculate_children_amount(number_of_children):
+    PER_CHILD_AMOUNT = 20
+    return number_of_children * PER_CHILD_AMOUNT
+
+def calculate_winter_supplement(number_of_children, family_composition, december_eligible):
+    if not december_eligible:
+        ineligible_amount = 0.0
+        return {
+            'baseAmount': ineligible_amount,
+            'childrenAmount': ineligible_amount,
+            'supplementAmount': ineligible_amount
+        }
+
+    base_amount = calculate_base_amount(family_composition)
+    children_amount = calculate_children_amount(number_of_children)
+    supplement_amount = base_amount + children_amount
+
+    return {
+            'baseAmount': base_amount,
+            'childrenAmount': children_amount,
+            'supplementAmount': supplement_amount
+    }

--- a/rules_engine.py
+++ b/rules_engine.py
@@ -1,29 +1,22 @@
-def calculate_base_amount(family_composition):
-    match family_composition:
-        case 'single':
-            base_amount = 60
-        case 'couple':
-            base_amount = 120
-        case _:
-            raise ValueError(f"Invalid family composition: {family_composition}")
+from constants import BASE_AMOUNTS, INELIGIBLE_AMOUNT, PER_CHILD_AMOUNTS
 
-    return base_amount
 
-def calculate_children_amount(number_of_children):
-    PER_CHILD_AMOUNT = 20
-    return number_of_children * PER_CHILD_AMOUNT
+def calculate_base_amount(program, family_composition, ):
+    return BASE_AMOUNTS[program][family_composition]
 
-def calculate_winter_supplement(number_of_children, family_composition, december_eligible):
-    if not december_eligible:
-        ineligible_amount = 0.0
+def calculate_children_amount(program, number_of_children, ):  
+    return PER_CHILD_AMOUNTS[program] * number_of_children
+
+def calculate_supplement(program, number_of_children, family_composition, eligible):
+    if not eligible:
         return {
-            'baseAmount': ineligible_amount,
-            'childrenAmount': ineligible_amount,
-            'supplementAmount': ineligible_amount
+            'baseAmount': INELIGIBLE_AMOUNT,
+            'childrenAmount': INELIGIBLE_AMOUNT,
+            'supplementAmount': INELIGIBLE_AMOUNT
         }
 
-    base_amount = calculate_base_amount(family_composition)
-    children_amount = calculate_children_amount(number_of_children)
+    base_amount = calculate_base_amount(program, family_composition)
+    children_amount = calculate_children_amount(program, number_of_children)
     supplement_amount = base_amount + children_amount
 
     return {

--- a/rules_engine.py
+++ b/rules_engine.py
@@ -5,8 +5,7 @@ def calculate_base_amount(family_composition):
         case 'couple':
             base_amount = 120
         case _:
-            #TODO i dont like this, revisit later
-            base_amount = -1
+            raise ValueError(f"Invalid family composition: {family_composition}")
 
     return base_amount
 

--- a/validation.py
+++ b/validation.py
@@ -1,3 +1,7 @@
+import logging 
+
+logger = logging.getLogger()
+
 def validate_input_data(data):
     required_keys = ['id', 'numberOfChildren', 'familyComposition', 'familyUnitInPayForDecember']
     if not all(key in data for key in required_keys):
@@ -6,12 +10,15 @@ def validate_input_data(data):
     
     # TODO make single/couple constant
     if data['familyComposition'] not in ['single', 'couple']:
+        logger.info(f'familyComposition: {data['familyComposition']}')
         raise ValueError(f'Invalid family composition. Must be one single or couple.')
     
     # TODO print/log data type and its value
     if not isinstance(data['numberOfChildren'], int) or data['numberOfChildren'] < 0:
+        logger.info(f'numberOfChildren: {data['numberOfChildren']}, type: {type(data['numberOfChildren'])}')
         raise ValueError('Invalid number of children. Must be a non-negative integer.')
     
     if not isinstance(data['familyUnitInPayForDecember'], bool):
+        logger.info(f'familyUnitInPayForDecember: {data['familyUnitInPayForDecember']}, type: {type(data['familyUnitInPayForDecember'])}')
         raise ValueError('Invalid familyUnitInPayForDecember. Must be a boolean.')
 

--- a/validation.py
+++ b/validation.py
@@ -1,0 +1,17 @@
+def validate_input_data(data):
+    required_keys = ['id', 'numberOfChildren', 'familyComposition', 'familyUnitInPayForDecember']
+    if not all(key in data for key in required_keys):
+        # TODO improve: which key is missing? what if more than one key is missing?
+        raise ValueError('Missing required input key(s)')
+    
+    # TODO make single/couple constant
+    if data['familyComposition'] not in ['single', 'couple']:
+        raise ValueError(f'Invalid family composition. Must be one single or couple.')
+    
+    # TODO print/log data type and its value
+    if not isinstance(data['numberOfChildren'], int) or data['numberOfChildren'] < 0:
+        raise ValueError('Invalid number of children. Must be a non-negative integer.')
+    
+    if not isinstance(data['familyUnitInPayForDecember'], bool):
+        raise ValueError('Invalid familyUnitInPayForDecember. Must be a boolean.')
+

--- a/validation.py
+++ b/validation.py
@@ -1,4 +1,6 @@
-import logging 
+import logging
+
+from constants import FAMILY_COMPOSITIONS 
 
 logger = logging.getLogger()
 
@@ -9,12 +11,10 @@ def validate_winter_supplement_input_data(data):
         logger.info(f'Missing required input key(s) {missing_keys}')
         raise ValueError(f'Missing required input key(s) {missing_keys}')
     
-    # TODO make single/couple constant
-    if data['familyComposition'] not in ['single', 'couple']:
+    if data['familyComposition'] not in FAMILY_COMPOSITIONS:
         logger.info(f'familyComposition: {data['familyComposition']}')
         raise ValueError(f'Invalid family composition. Must be one single or couple.')
     
-    # TODO print/log data type and its value
     if not isinstance(data['numberOfChildren'], int) or data['numberOfChildren'] < 0:
         logger.info(f'numberOfChildren: {data['numberOfChildren']}, type: {type(data['numberOfChildren'])}')
         raise ValueError('Invalid number of children. Must be a non-negative integer.')

--- a/validation.py
+++ b/validation.py
@@ -2,11 +2,12 @@ import logging
 
 logger = logging.getLogger()
 
-def validate_input_data(data):
-    required_keys = ['id', 'numberOfChildren', 'familyComposition', 'familyUnitInPayForDecember']
-    if not all(key in data for key in required_keys):
-        # TODO improve: which key is missing? what if more than one key is missing?
-        raise ValueError('Missing required input key(s)')
+def validate_winter_supplement_input_data(data):
+    required_keys = {'id', 'numberOfChildren', 'familyComposition', 'familyUnitInPayForDecember'}
+    missing_keys = required_keys - data.keys()
+    if missing_keys:
+        logger.info(f'Missing required input key(s) {missing_keys}')
+        raise ValueError(f'Missing required input key(s) {missing_keys}')
     
     # TODO make single/couple constant
     if data['familyComposition'] not in ['single', 'couple']:


### PR DESCRIPTION
- MQTT client consumes message from BRE/calculateWinterSupplementInput topic
- Input data is validated to ensure correct keys and their types are present
- Winter supplement eligibility is calculated in rules_engine.py
- Added constants.py for common business logic constants 
- Winter supplement calculation results are published to BRE/calculateWinterSupplementOutput
- Refactored MQTT keepalive to be a constant for consistency 