### PR TITLE
Encapsulate MQTT client connection logic into wrapper class MQTTClientWrapper

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,0 +1,24 @@
+import paho.mqtt.client as mqtt
+
+from config import HOST, PORT, KEEP_ALIVE
+
+
+class MQTTClientWrapper:
+    def __init__(self, input_topic, output_topic, topic_id, on_message):
+        self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+        self.input_topic = input_topic
+        self.output_topic = output_topic
+        self.topic_id = topic_id
+
+        self.client.on_connect = self.__on_connect
+        self.client.on_message = on_message
+
+    def __on_connect(self, client, userdata, flags, reason_code, properties):
+        print(f'Connected to topic {self.input_topic} with result code {reason_code}')
+        client.subscribe(f'{self.input_topic}/{self.topic_id}')
+
+    def start(self):
+        self.client.connect(HOST, PORT, KEEP_ALIVE)
+        self.client.loop_forever()
+
+    

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 HOST = 'test.mosquitto.org'
 PORT = 1883
 KEEP_ALIVE = 60
-TOPIC_ID = '44574422-0088-4f4e-83e4-053dffd7c65a'
 INPUT_TOPIC = 'BRE/calculateWinterSupplementInput'
 OUTPUT_TOPIC = 'BRE/calculateWinterSupplementOutput'
+TOPIC_ID = '44574422-0088-4f4e-83e4-053dffd7c65a'

--- a/main.py
+++ b/main.py
@@ -1,15 +1,10 @@
 import json
 
-import paho.mqtt.client as mqtt
-
-from config import HOST, INPUT_TOPIC, KEEP_ALIVE, OUTPUT_TOPIC, PORT, TOPIC_ID
+from client import MQTTClientWrapper
+from config import INPUT_TOPIC, OUTPUT_TOPIC, TOPIC_ID
 from rules_engine import calculate_supplement
 from validation import validate_winter_supplement_input_data
 
-
-def on_connect(client, userdata, flags, reason_code, properties):
-    print(f'Connected with result code {reason_code}')
-    client.subscribe(f'{INPUT_TOPIC}/{TOPIC_ID}')
 
 def on_message(client, userdata, msg):
     print(f'{msg.topic}: {msg.payload}')
@@ -44,10 +39,5 @@ def on_message(client, userdata, msg):
     print(encoded_output_data) 
     client.publish(f'{OUTPUT_TOPIC}/{TOPIC_ID}', encoded_output_data)
 
-mqttc = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
-mqttc.on_connect = on_connect
-mqttc.on_message = on_message
-
-mqttc.connect(HOST, PORT, KEEP_ALIVE)
-
-mqttc.loop_forever()
+client = MQTTClientWrapper(INPUT_TOPIC, OUTPUT_TOPIC, TOPIC_ID, on_message)
+client.start()


### PR DESCRIPTION
- MQTT client connection logic is handled in the wrapper MQTTClientWrapper instead of main.py
- main.py just focuses on handling the on_message logic (don't love this), instantiating, and starting the MQTT client